### PR TITLE
fix: fdtdec_setup

### DIFF
--- a/lib/fdtdec.c
+++ b/lib/fdtdec.c
@@ -1686,7 +1686,7 @@ int fdtdec_setup(void)
 	}
 
 	/* Otherwise, the devicetree is typically appended to U-Boot */
-	if (ret) {
+	if (!ret) {
 		if (IS_ENABLED(CONFIG_OF_SEPARATE)) {
 			gd->fdt_blob = fdt_find_separate();
 			gd->fdt_src = FDTSRC_SEPARATE;


### PR DESCRIPTION
the CONFIG_OF_SEPARATE will only take effect in the following cases: enable CONFIG_BLOBLIST, find devicetree in bloblist successfully and enable CONFIG_OF_SEPARATE .
the url https://www.denx.de/wiki/U-Boot/Patches was disappear, so i can only pr here.