### PR TITLE
arm: mach-imx: imx8m: Fix disabled VPU node names

### DIFF
--- a/arch/arm/mach-imx/imx8m/soc.c
+++ b/arch/arm/mach-imx/imx8m/soc.c
@@ -1118,10 +1118,10 @@ int disable_vpu_nodes(void *blob)
 		"/soc@0/video-codec@38310000",
 		"/soc@0/blk-ctrl@38330000",
 		"/soc@0/blk-ctl@38330000",
-		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@19",
-		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@20",
-		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@21",
-		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@22"
+		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@8",
+		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@11",
+		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@12",
+		"/soc@0/bus@30000000/gpc@303a0000/pgc/power-domain@13"
 	};
 
 	if (is_imx8mq())


### PR DESCRIPTION
Since kernel upstream commit 2f8405fb077b ("arm64: dts: imx8mp: Fix pgc vpu locations") the pgc vpu nodes got renamed.

This has not been reflected in the NXP
commit: 7919847247e6 ("LF-9055 imx8m: Fix iMX8MP QuadLite kernel boot hang") Where the power-domains are disabled before kernel boot.

Update the node names.

Fixes: 7919847247e6 ("LF-9055 imx8m: Fix iMX8MP QuadLite kernel boot hang")
